### PR TITLE
Avoid a null-reference upon application load when the 'Greeting' feature flag is not found.

### DIFF
--- a/QuoteOfTheDay/Pages/Index.cshtml.cs
+++ b/QuoteOfTheDay/Pages/Index.cshtml.cs
@@ -12,8 +12,12 @@ public class Quote
     public string Author { get; set; }
 }
 
-public class IndexModel(IVariantFeatureManagerSnapshot featureManager, TelemetryClient telemetryClient) : PageModel
+public class IndexModel(
+    ILogger<IndexModel> logger,
+    IVariantFeatureManagerSnapshot featureManager,
+    TelemetryClient telemetryClient) : PageModel
 {
+    private readonly ILogger _logger = logger;
     private readonly IVariantFeatureManagerSnapshot _featureManager = featureManager;
     private readonly TelemetryClient _telemetryClient = telemetryClient;
 
@@ -34,7 +38,16 @@ public class IndexModel(IVariantFeatureManagerSnapshot featureManager, Telemetry
 
         Variant variant = await _featureManager.GetVariantAsync("Greeting", HttpContext.RequestAborted);
 
-        ShowGreeting = variant.Configuration.Get<bool>();
+        if (variant != null)
+        {
+            ShowGreeting = variant.Configuration.Get<bool>();
+        }
+        else
+        {
+            _logger.LogWarning("Greeting variant not found. Please define a variant feature flag in Azure App Configuration named 'Greeting' with 'true' and 'false' variants.");
+
+            ShowGreeting = false;
+        }
     }
 
     public IActionResult OnPostHeartQuoteAsync()


### PR DESCRIPTION
Currently if the application is used without first defining a 'Greeting' feature flag, a null-ref will be hit. This PR updates the app to be resilient and log a warning instead.