### PR TITLE
Use Azure Identity instead of connection string for authentication

### DIFF
--- a/QuoteOfTheDay/Program.cs
+++ b/QuoteOfTheDay/Program.cs
@@ -1,3 +1,4 @@
+using Azure.Identity;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using QuoteOfTheDay.Data;
@@ -8,13 +9,13 @@ using Microsoft.FeatureManagement;
 
 var builder = WebApplication.CreateBuilder(args);
 
-var appConfigurationConnectionString = builder.Configuration["AzureAppConfigurationConnectionString"];
-var applicationInsightsConnectionString = builder.Configuration["ApplicationInsightsConnectionString"];
+var appConfigurationEndpoint = builder.Configuration["APPCONFIG_ENDPOINT"];
+var applicationInsightsConnectionString = builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"];
 
 builder.Configuration
     .AddAzureAppConfiguration(o =>
     {
-        o.Connect(appConfigurationConnectionString);
+        o.Connect(new Uri(appConfigurationEndpoint), new DefaultAzureCredential());
         o.UseFeatureFlags();
         o.ConfigureStartupOptions(startupOptions => {
             startupOptions.Timeout = TimeSpan.FromSeconds(30);

--- a/QuoteOfTheDay/Program.cs
+++ b/QuoteOfTheDay/Program.cs
@@ -19,15 +19,17 @@ if (isRunningFromSetupScript)
 var appConfigurationEndpoint = builder.Configuration["APPCONFIG_ENDPOINT"];
 var applicationInsightsConnectionString = builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"];
 
-builder.Configuration
-    .AddAzureAppConfiguration(o =>
-    {
-        o.Connect(new Uri(appConfigurationEndpoint), new DefaultAzureCredential());
-        o.UseFeatureFlags();
-        o.ConfigureStartupOptions(startupOptions => {
-            startupOptions.Timeout = TimeSpan.FromSeconds(30);
+if (!string.IsNullOrEmpty(appConfigurationEndpoint)) {
+    builder.Configuration
+        .AddAzureAppConfiguration(o =>
+        {
+            o.Connect(new Uri(appConfigurationEndpoint), new DefaultAzureCredential());
+            o.UseFeatureFlags();
+            o.ConfigureStartupOptions(startupOptions => {
+                startupOptions.Timeout = TimeSpan.FromSeconds(30);
+            });
         });
-    }, optional: isRunningFromSetupScript);
+}
 
 // Add Application Insights telemetry.
 builder.Services.AddApplicationInsightsTelemetry(

--- a/QuoteOfTheDay/Program.cs
+++ b/QuoteOfTheDay/Program.cs
@@ -9,8 +9,14 @@ using Microsoft.FeatureManagement;
 
 var builder = WebApplication.CreateBuilder(args);
 
-var placeholderEndpoint = "https://azure.azconfig.io";
-var appConfigurationEndpoint = builder.Configuration["APPCONFIG_ENDPOINT"] ?? placeholderEndpoint;
+// Check if we're running from the database setup script
+bool isRunningFromSetupScript = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("RUNNING_EF_MIGRATIONS_SETUP"));
+if (isRunningFromSetupScript)
+{
+    Console.WriteLine("Running database setup - skipping Azure App Configuration");
+}
+
+var appConfigurationEndpoint = builder.Configuration["APPCONFIG_ENDPOINT"];
 var applicationInsightsConnectionString = builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"];
 
 builder.Configuration
@@ -21,7 +27,7 @@ builder.Configuration
         o.ConfigureStartupOptions(startupOptions => {
             startupOptions.Timeout = TimeSpan.FromSeconds(30);
         });
-    }, optional: appConfigurationEndpoint.Equals(placeholderEndpoint));
+    }, optional: isRunningFromSetupScript);
 
 // Add Application Insights telemetry.
 builder.Services.AddApplicationInsightsTelemetry(

--- a/QuoteOfTheDay/Program.cs
+++ b/QuoteOfTheDay/Program.cs
@@ -9,7 +9,8 @@ using Microsoft.FeatureManagement;
 
 var builder = WebApplication.CreateBuilder(args);
 
-var appConfigurationEndpoint = builder.Configuration["APPCONFIG_ENDPOINT"];
+var placeholderEndpoint = "https://azure.azconfig.io";
+var appConfigurationEndpoint = builder.Configuration["APPCONFIG_ENDPOINT"] ?? placeholderEndpoint;
 var applicationInsightsConnectionString = builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"];
 
 builder.Configuration
@@ -20,7 +21,7 @@ builder.Configuration
         o.ConfigureStartupOptions(startupOptions => {
             startupOptions.Timeout = TimeSpan.FromSeconds(30);
         });
-    });
+    }, optional: appConfigurationEndpoint.Equals(placeholderEndpoint));
 
 // Add Application Insights telemetry.
 builder.Services.AddApplicationInsightsTelemetry(

--- a/QuoteOfTheDay/QuoteOfTheDay.csproj
+++ b/QuoteOfTheDay/QuoteOfTheDay.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.13.1" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.8" />

--- a/infra/Setup-CreateDatabase.ps1
+++ b/infra/Setup-CreateDatabase.ps1
@@ -19,7 +19,6 @@ if ($dotnetSDK -eq $null) {
 }
 
 dotnet tool install --global dotnet-ef
-dotnet add package Microsoft.EntityFrameworkCore.Design
 dotnet ef migrations add InitialCreate
 dotnet ef database update
 

--- a/infra/Setup-CreateDatabase.ps1
+++ b/infra/Setup-CreateDatabase.ps1
@@ -18,9 +18,19 @@ if ($dotnetSDK -eq $null) {
     Write-Host "The .NET SDK is already installed."
 }
 
+# Set environment variable to indicate EF migrations are running from setup script
+$env:RUNNING_EF_MIGRATIONS_SETUP = "true"
+
+# Temporarily set Azure environment variables to null to prevent connection attempts
+$env:APPCONFIG_ENDPOINT = $null
+$env:APPLICATIONINSIGHTS_CONNECTION_STRING = $null
+
 dotnet tool install --global dotnet-ef
 dotnet ef migrations add InitialCreate
 dotnet ef database update
+
+# Clean up environment variable
+$env:RUNNING_EF_MIGRATIONS_SETUP = $null
 
 Write-Host "Created the database file."
 

--- a/infra/app/QuoteOfTheDay.bicep
+++ b/infra/app/QuoteOfTheDay.bicep
@@ -2,17 +2,11 @@ param name string
 param location string = resourceGroup().location
 param tags object = {}
 
-param identityName string
 param applicationInsightsName string
 @secure()
 param appDefinition object
 param appServicePlanId string
 param appConfigurationName string
-
-resource identity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
-  name: identityName
-  location: location
-}
 
 resource applicationInsights 'Microsoft.Insights/components@2020-02-02' existing = {
   name: applicationInsightsName

--- a/infra/app/QuoteOfTheDay.bicep
+++ b/infra/app/QuoteOfTheDay.bicep
@@ -6,8 +6,8 @@ param identityName string
 param applicationInsightsName string
 @secure()
 param appDefinition object
-param appConfigurationConnectionString string
 param appServicePlanId string
+param appConfigurationName string
 
 resource identity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
   name: identityName
@@ -23,8 +23,7 @@ resource appService 'Microsoft.Web/sites@2023-01-01' = {
   location: location
   tags: union(tags, {'azd-service-name':  'QuoteOfTheDay' })
   identity: {
-    type: 'UserAssigned'
-    userAssignedIdentities: { '${identity.id}': {} }
+    type: 'SystemAssigned'
   }
   properties: {
     serverFarmId: appServicePlanId
@@ -36,13 +35,32 @@ resource appService 'Microsoft.Web/sites@2023-01-01' = {
   }
 }
 
+@description('This is the built-in app configuration data reader role. See https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#app-configuration-data-reader')
+resource appConfigDataReaderDefinition 'Microsoft.Authorization/roleDefinitions@2018-01-01-preview' existing = {
+  name: '516239f1-63e1-4d78-a4de-a74fb236a071'
+}
+
+resource appConfiguration 'Microsoft.AppConfiguration/configurationStores@2023-09-01-preview' existing = {
+  name: appConfigurationName
+}
+
+resource appConfigDataReaderRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(resourceGroup().id, appConfiguration.id, appConfigDataReaderDefinition.id)
+  scope: appConfiguration
+  properties: {
+    roleDefinitionId: appConfigDataReaderDefinition.id
+    principalId: appService.identity.principalId
+    principalType: 'ServicePrincipal' 
+  }
+}
+
 module configAppSettings '../shared/appservice-appsettings.bicep' = {
   name: '${name}-appSettings'
   params: {
     name: appService.name
     appSettings: union(
       {
-        ApplicationInsightsConnectionString: applicationInsights.properties.ConnectionString
+        APPLICATIONINSIGHTS_CONNECTION_STRING: applicationInsights.properties.ConnectionString
       },
       {
         ENABLE_ORYX_BUILD: true
@@ -51,7 +69,7 @@ module configAppSettings '../shared/appservice-appsettings.bicep' = {
         SCM_DO_BUILD_DURING_DEPLOYMENT: false
       },
       {
-        AzureAppConfigurationConnectionString: appConfigurationConnectionString
+        APPCONFIG_ENDPOINT: appConfiguration.properties.endpoint
       },
       appDefinition.settings)
   }

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -85,11 +85,11 @@ module quoteOfTheDay './app/QuoteOfTheDay.bicep' = {
     identityName: '${abbrs.managedIdentityUserAssignedIdentities}quoteoftheda-${resourceToken}'
     applicationInsightsName: monitoring.outputs.applicationInsightsName
     appDefinition: quoteOfTheDayDefinition
-    appConfigurationConnectionString: appConfiguration.outputs.appConfigurationConnectionString
     appServicePlanId: appServicePlan.outputs.id
+    appConfigurationName: appConfiguration.outputs.appConfigurationName
   }
   scope: rg
 }
 
-output AzureAppConfigurationConnectionString string = appConfiguration.outputs.appConfigurationConnectionString
-output ApplicationInsightsConnectionString string = monitoring.outputs.applicationInsightsConnectionString
+output APPCONFIG_ENDPOINT string = appConfiguration.outputs.appConfigurationEndpoint
+output APPLICATIONINSIGHTS_CONNECTION_STRING string = monitoring.outputs.applicationInsightsConnectionString

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -82,7 +82,6 @@ module quoteOfTheDay './app/QuoteOfTheDay.bicep' = {
     name: '${abbrs.appContainerApps}quoteoftheda-${resourceToken}'
     location: location
     tags: tags
-    identityName: '${abbrs.managedIdentityUserAssignedIdentities}quoteoftheda-${resourceToken}'
     applicationInsightsName: monitoring.outputs.applicationInsightsName
     appDefinition: quoteOfTheDayDefinition
     appServicePlanId: appServicePlan.outputs.id

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -23,18 +23,6 @@
       "LAWsku": {
         "value": "pergb2018"
       },
-      "SAName": {
-        "value": "sapreview"
-      },
-      "SAKind": {
-        "value": "StorageV2"
-      },
-      "SASkuName": {
-        "value": "Standard_LRS"
-      },
-      "SASkuTier": {
-        "value": "Standard"
-      },
       "AIname": {
         "value": "aipreview"
       },

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -18,7 +18,7 @@
         "value": "lawpreview"
       },
       "location": {
-        "value": "eastus"
+        "value": "${AZURE_LOCATION}"
       },
       "LAWsku": {
         "value": "pergb2018"

--- a/infra/modules/fetch-container-image.bicep
+++ b/infra/modules/fetch-container-image.bicep
@@ -1,8 +1,0 @@
-param exists bool
-param name string
-
-resource existingApp 'Microsoft.App/containerApps@2023-05-02-preview' existing = if (exists) {
-  name: name
-}
-
-output containers array = exists ? existingApp.properties.template.containers : []

--- a/infra/shared/appConfiguration.bicep
+++ b/infra/shared/appConfiguration.bicep
@@ -81,7 +81,5 @@ resource variantFeatureFlagGreeting 'Microsoft.AppConfiguration/configurationSto
   }
 }
 
-var readonlyKey = filter(appConfigurationStore.listKeys().value, k => k.name == 'Primary Read Only')[0]
-
-output appConfigurationConnectionString string = readonlyKey.connectionString
+output appConfigurationEndpoint string = appConfigurationStore.properties.endpoint
 output appConfigurationName string = appConfigurationStore.name


### PR DESCRIPTION
## Purpose
* Uses Azure Identity for authentication to Azure App Configuration, which is preferred over connection string for security

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: Security improvement
```

## How to Test
* Use README instructions to ultimately run `azd up`, see that the App Service deployment runs as expected and doesn't fail due to authentication

## What to Check
Verify that the following are valid
* All mentions of App Configuration connection strings are gone, replaced with Azure Identity credentials and the App Configuration endpoint

## Other Information
<!-- Add any other helpful information that may be needed here. -->